### PR TITLE
Update tracker rule generation to be deterministic

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -35,7 +35,8 @@ let package = Package(
             name: "TrackerRadarKitTests",
             dependencies: ["TrackerRadarKit"],
             resources: [
-                .process("Resources/trackerData.json")
+                .process("Resources/trackerData.json"),
+                .process("Resources/mockTrackerData.json")
             ])
     ]
 )

--- a/Sources/TrackerRadarKit/ArrayExtension.swift
+++ b/Sources/TrackerRadarKit/ArrayExtension.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  ArrayExtension.swift
 //
 //  Copyright © 2021 DuckDuckGo. All rights reserved.
 //

--- a/Sources/TrackerRadarKit/ArrayExtension.swift
+++ b/Sources/TrackerRadarKit/ArrayExtension.swift
@@ -1,0 +1,48 @@
+//
+//  File.swift
+//
+//  Copyright © 2021 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+extension Array where Element: Hashable {
+
+    func removeDuplicates() -> [Element] {
+        var existingElements = Set<Element>()
+        return self.filter { existingElements.insert($0).inserted }
+    }
+
+}
+
+extension Array where Element == String {
+
+    func prefixAll(with prefix: String) -> [String] {
+        return map { prefix + $0 }
+    }
+
+    func wildcards() -> [String] {
+        return prefixAll(with: "*")
+    }
+
+    func normalizeAsUrls() -> [String] {
+        return map { ContentBlockerRulesBuilder.Constants.subDomainPrefix + $0 + "/.*" }
+    }
+
+    func mapResources() -> [ContentBlockerRule.Trigger.ResourceType] {
+        return compactMap { ContentBlockerRulesBuilder.resourceMapping[$0] }
+    }
+
+}

--- a/Sources/TrackerRadarKit/ArrayExtension.swift
+++ b/Sources/TrackerRadarKit/ArrayExtension.swift
@@ -37,10 +37,6 @@ extension Array where Element == String {
         return prefixAll(with: "*")
     }
 
-    func normalizeAsUrls() -> [String] {
-        return map { ContentBlockerRulesBuilder.Constants.subDomainPrefix + $0 + "/.*" }
-    }
-
     func mapResources() -> [ContentBlockerRule.Trigger.ResourceType] {
         return compactMap { ContentBlockerRulesBuilder.resourceMapping[$0] }
     }

--- a/Sources/TrackerRadarKit/ContentBlockerRulesBuilder.swift
+++ b/Sources/TrackerRadarKit/ContentBlockerRulesBuilder.swift
@@ -48,16 +48,18 @@ public struct ContentBlockerRulesBuilder {
             buildRules(from: $0)
         }.flatMap { $0 }
         
-        var cnameTrackers = [String: KnownTracker]()
+        var cnameTrackers: [(String, KnownTracker)] = []
+
         trackerData.cnames?.forEach { key, value in
             guard let knownTracker = trackerData.findTracker(byCname: value) else { return }
             let newTracker = knownTracker.copy(withNewDomain: key)
-            cnameTrackers[key] = newTracker
+            cnameTrackers.append((key, newTracker))
         }
-        let cnameRules = cnameTrackers.values.compactMap {
-            buildRules(from: $0)
+
+        let cnameRules = cnameTrackers.map {
+            buildRules(from: $1)
         }.flatMap { $0 }
-        
+
         return trackerRules + cnameRules + buildExceptions(from: exceptions, andUnprotectedDomains: tempUnprotectedDomains)
     }
     

--- a/Sources/TrackerRadarKit/ContentBlockerRulesBuilder.swift
+++ b/Sources/TrackerRadarKit/ContentBlockerRulesBuilder.swift
@@ -194,34 +194,6 @@ fileprivate extension String {
     
 }
 
-fileprivate extension Array where Element: Hashable {
-    
-    func removeDuplicates() -> [Element] {
-        return Array(Set(self))
-    }
-    
-}
-
-fileprivate extension Array where Element == String {
-    
-    func prefixAll(with prefix: String) -> [String] {
-        return map { prefix + $0 }
-    }
-    
-    func wildcards() -> [String] {
-        return prefixAll(with: "*")
-    }
-    
-    func normalizeAsUrls() -> [String] {
-        return map { ContentBlockerRulesBuilder.Constants.subDomainPrefix + $0 + "/.*" }
-    }
-    
-    func mapResources() -> [ContentBlockerRule.Trigger.ResourceType] {
-        return compactMap { ContentBlockerRulesBuilder.resourceMapping[$0] }
-    }
-    
-}
-
 fileprivate extension KnownTracker.Rule {
     
     func normalizedRule() -> String {

--- a/Sources/TrackerRadarKit/ContentBlockerRulesBuilder.swift
+++ b/Sources/TrackerRadarKit/ContentBlockerRulesBuilder.swift
@@ -48,17 +48,15 @@ public struct ContentBlockerRulesBuilder {
             buildRules(from: $0)
         }.flatMap { $0 }
         
-        var cnameTrackers: [(String, KnownTracker)] = []
+        var cnameTrackers = [KnownTracker]()
 
         trackerData.cnames?.forEach { key, value in
             guard let knownTracker = trackerData.findTracker(byCname: value) else { return }
             let newTracker = knownTracker.copy(withNewDomain: key)
-            cnameTrackers.append((key, newTracker))
+            cnameTrackers.append(newTracker)
         }
 
-        let cnameRules = cnameTrackers.map {
-            buildRules(from: $1)
-        }.flatMap { $0 }
+        let cnameRules = cnameTrackers.map(buildRules(from:)).flatMap { $0 }
 
         return trackerRules + cnameRules + buildExceptions(from: exceptions, andUnprotectedDomains: tempUnprotectedDomains)
     }

--- a/Tests/TrackerRadarKitTests/ArrayExtensionTests.swift
+++ b/Tests/TrackerRadarKitTests/ArrayExtensionTests.swift
@@ -37,4 +37,33 @@ class ArrayExtensionTests: XCTestCase {
         XCTAssertEqual(deduplicated, Array(1...100))
     }
 
+    func testPrefixAll() {
+        let strings = ["World"]
+        let prefixed = strings.prefixAll(with: "👋 Hello ")
+
+        XCTAssertEqual(prefixed, ["👋 Hello World"])
+    }
+
+    func testWildcards() {
+        let strings = ["a", "b", "c"]
+        let wildcards = strings.wildcards()
+
+        XCTAssertEqual(wildcards, ["*a", "*b", "*c"])
+    }
+
+    func testMapResources() {
+        let resources = [
+            "script",
+            "xmlhttprequest",
+            "subdocument",
+            "image",
+            "stylesheet",
+            "invalid-resource-type"
+        ]
+
+        let mapped = resources.mapResources()
+
+        XCTAssertEqual(mapped, [.script, .raw, .document, .image, .stylesheet])
+    }
+
 }

--- a/Tests/TrackerRadarKitTests/ArrayExtensionTests.swift
+++ b/Tests/TrackerRadarKitTests/ArrayExtensionTests.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  ArrayExtensionTests.swift
 //
 //  Copyright © 2021 DuckDuckGo. All rights reserved.
 //

--- a/Tests/TrackerRadarKitTests/ArrayExtensionTests.swift
+++ b/Tests/TrackerRadarKitTests/ArrayExtensionTests.swift
@@ -1,0 +1,40 @@
+//
+//  File.swift
+//
+//  Copyright © 2021 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+@testable import TrackerRadarKit
+
+class ArrayExtensionTests: XCTestCase {
+
+    func testRemoveDuplicates_noDuplicates() {
+        let array = Array(1...10)
+        let deduplicated = array.removeDuplicates()
+
+        XCTAssertEqual(array, deduplicated)
+    }
+
+    func testRemoveDuplicates_duplicates() {
+        let array = Array(1...100) + Array(1...100)
+        let deduplicated = array.removeDuplicates()
+
+        XCTAssertEqual(array.count, 200)
+        XCTAssertEqual(deduplicated.count, 100)
+        XCTAssertEqual(deduplicated, Array(1...100))
+    }
+
+}

--- a/Tests/TrackerRadarKitTests/ContentBlockerRulesBuilderTests.swift
+++ b/Tests/TrackerRadarKitTests/ContentBlockerRulesBuilderTests.swift
@@ -58,9 +58,26 @@ class ContentBlockerRulesBuilderTests: XCTestCase {
             andTemporaryUnprotectedDomains: []
         ).map { $0.trigger.urlFilter }
 
-        // Temporary quick checks to see if these are differences, limited to 50 because these tests are failing even on this limited subset.
-        XCTAssertEqual(firstGeneration.prefix(upTo: 50), secondGeneration.prefix(upTo: 50))
-        XCTAssertEqual(firstGeneration.suffix(50), secondGeneration.suffix(50))
+        // The data set is large enough that comparing these is slow, so check batches at the start and end.
+        XCTAssertEqual(firstGeneration.prefix(upTo: 1000), secondGeneration.prefix(upTo: 1000))
+        XCTAssertEqual(firstGeneration.suffix(1000), secondGeneration.suffix(1000))
+    }
+
+    func testLoadingRulesIsDeterministic_MockData() {
+        let data = JSONTestDataLoader.mockTrackerData
+        let mockData = try! JSONDecoder().decode(TrackerData.self, from: data)
+
+        let firstGeneration = ContentBlockerRulesBuilder(trackerData: mockData).buildRules(
+            withExceptions: [],
+            andTemporaryUnprotectedDomains: []
+        ).map { $0.trigger.urlFilter }
+
+        let secondGeneration = ContentBlockerRulesBuilder(trackerData: mockData).buildRules(
+            withExceptions: [],
+            andTemporaryUnprotectedDomains: []
+        ).map { $0.trigger.urlFilter }
+
+        XCTAssertEqual(firstGeneration, secondGeneration)
     }
 
 }

--- a/Tests/TrackerRadarKitTests/Resources/mockTrackerData.json
+++ b/Tests/TrackerRadarKitTests/Resources/mockTrackerData.json
@@ -60,11 +60,6 @@
                     "rule": "tracker-2\\.com\\/tracking\\/tracker2\\.js",
                     "fingerprinting": 1,
                     "cookies": 0.01
-                },
-                {
-                    "rule": "tracker-2\\.com\\/tracking\\/tracker3\\.js",
-                    "fingerprinting": 1,
-                    "cookies": 0.01
                 }
             ]
         },
@@ -91,25 +86,7 @@
                     "cookies": 0.01
                 }
             ]
-        },
-        "tracker-a.com": {
-            "domain": "tracker-a.com",
-            "owner": {
-                "name": "Tracker A, Inc.",
-                "displayName": "Tracker A"
-            },
-            "prevalence": 1,
-            "fingerprinting": 1,
-            "cookies": 1,
-            "categories": [
-                "Ad Motivated Tracking",
-                "Advertising",
-                "Analytics",
-                "Third-Party Analytics Marketing"
-            ],
-            "default": "block",
-            "rules": []
-        },
+        }
     },
     "entities": {
         "Tracker 1, Inc.": {
@@ -132,20 +109,12 @@
             ],
             "prevalence": 1,
             "displayName": "Tracker 3"
-        },
-        "Tracker A, Inc.": {
-            "domains": [
-                "tracker-a.com"
-            ],
-            "prevalence": 1,
-            "displayName": "Tracker A"
         }
     },
     "domains": {
         "tracker-1.com": "Tracker 1",
         "tracker-2.com": "Tracker 2",
-        "tracker-3.com": "Tracker 3",
-        "tracker-a.com": "Tracker A"
+        "tracker-3.com": "Tracker 3"
     },
     "cnames": {
         "tracker-1.com": "cname.tracker-1.com",

--- a/Tests/TrackerRadarKitTests/Resources/mockTrackerData.json
+++ b/Tests/TrackerRadarKitTests/Resources/mockTrackerData.json
@@ -1,0 +1,155 @@
+{
+    "trackers": {
+        "tracker-1.com": {
+            "domain": "tracker-1.com",
+            "owner": {
+                "name": "Tracker 1, Inc.",
+                "displayName": "Tracker 1"
+            },
+            "prevalence": 1,
+            "fingerprinting": 1,
+            "cookies": 1,
+            "categories": [
+                "Ad Motivated Tracking",
+                "Advertising",
+                "Analytics",
+                "Third-Party Analytics Marketing"
+            ],
+            "default": "block",
+            "rules": [
+                {
+                    "rule": "tracker-1\\.com\\/tracking\\/tracker\\.js",
+                    "fingerprinting": 1,
+                    "cookies": 0.01
+                },
+                {
+                    "rule": "tracker-1\\.com\\/tracking\\/tracker2\\.js",
+                    "fingerprinting": 1,
+                    "cookies": 0.01
+                },
+                {
+                    "rule": "tracker-1\\.com\\/tracking\\/tracker3\\.js",
+                    "fingerprinting": 1,
+                    "cookies": 0.01
+                }
+            ]
+        },
+        "tracker-2.com": {
+            "domain": "tracker-2.com",
+            "owner": {
+                "name": "Tracker 2, Inc.",
+                "displayName": "Tracker 2"
+            },
+            "prevalence": 1,
+            "fingerprinting": 1,
+            "cookies": 1,
+            "categories": [
+                "Ad Motivated Tracking",
+                "Advertising",
+                "Analytics",
+                "Third-Party Analytics Marketing"
+            ],
+            "default": "block",
+            "rules": [
+                {
+                    "rule": "tracker-2\\.com\\/tracking\\/tracker\\.js",
+                    "fingerprinting": 1,
+                    "cookies": 0.01
+                },
+                {
+                    "rule": "tracker-2\\.com\\/tracking\\/tracker2\\.js",
+                    "fingerprinting": 1,
+                    "cookies": 0.01
+                },
+                {
+                    "rule": "tracker-2\\.com\\/tracking\\/tracker3\\.js",
+                    "fingerprinting": 1,
+                    "cookies": 0.01
+                }
+            ]
+        },
+        "tracker-3.com": {
+            "domain": "tracker-3.com",
+            "owner": {
+                "name": "Tracker 3, Inc.",
+                "displayName": "Tracker 3"
+            },
+            "prevalence": 1,
+            "fingerprinting": 1,
+            "cookies": 1,
+            "categories": [
+                "Ad Motivated Tracking",
+                "Advertising",
+                "Analytics",
+                "Third-Party Analytics Marketing"
+            ],
+            "default": "block",
+            "rules": [
+                {
+                    "rule": "tracker-3\\.com\\/tracking\\/tracker\\.js",
+                    "fingerprinting": 1,
+                    "cookies": 0.01
+                }
+            ]
+        },
+        "tracker-a.com": {
+            "domain": "tracker-a.com",
+            "owner": {
+                "name": "Tracker A, Inc.",
+                "displayName": "Tracker A"
+            },
+            "prevalence": 1,
+            "fingerprinting": 1,
+            "cookies": 1,
+            "categories": [
+                "Ad Motivated Tracking",
+                "Advertising",
+                "Analytics",
+                "Third-Party Analytics Marketing"
+            ],
+            "default": "block",
+            "rules": []
+        },
+    },
+    "entities": {
+        "Tracker 1, Inc.": {
+            "domains": [
+                "tracker-1.com"
+            ],
+            "prevalence": 1,
+            "displayName": "Tracker 1"
+        },
+        "Tracker 2, Inc.": {
+            "domains": [
+                "tracker-2.com"
+            ],
+            "prevalence": 1,
+            "displayName": "Tracker 2"
+        },
+        "Tracker 3, Inc.": {
+            "domains": [
+                "tracker-3.com"
+            ],
+            "prevalence": 1,
+            "displayName": "Tracker 3"
+        },
+        "Tracker A, Inc.": {
+            "domains": [
+                "tracker-a.com"
+            ],
+            "prevalence": 1,
+            "displayName": "Tracker A"
+        }
+    },
+    "domains": {
+        "tracker-1.com": "Tracker 1",
+        "tracker-2.com": "Tracker 2",
+        "tracker-3.com": "Tracker 3",
+        "tracker-a.com": "Tracker A"
+    },
+    "cnames": {
+        "tracker-1.com": "cname.tracker-1.com",
+        "tracker-2.com": "cname.tracker-2.com",
+        "tracker-3.com": "cname.tracker-3.com",
+    }
+}

--- a/Tests/TrackerRadarKitTests/Test Utilities/JSONTestDataLoader.swift
+++ b/Tests/TrackerRadarKitTests/Test Utilities/JSONTestDataLoader.swift
@@ -24,6 +24,10 @@ class JSONTestDataLoader {
         JSONTestDataLoader().fromJSONFile("trackerData")
     }
 
+    static var mockTrackerData: Data {
+        JSONTestDataLoader().fromJSONFile("mockTrackerData")
+    }
+
     private var bundle: Bundle {
         Bundle.module
     }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1199178362774117/1199711833257325/f
Tech Design URL:
CC: @brindy 

**Description**:

This PR fixes two issues which caused content blocker rules to be generated in a different order each time:

1. The `removeDuplicates` function was passing an array through a set in order to remove dupes, but sets aren't ordered so the result was random each time – this is problematic since content blocker rules _do_ care about order
2. The `cnameRules` array was seeing the same randomization issue, as it was being created by iterating through a dictionary which also has no promise of ordering

**Steps to test this PR**:
1. Run the unit tests and ensure they pass
1. Pull down the [equivalent iOS PR](https://github.com/duckduckgo/iOS/pull/818) and test that content blocking rules are working on various sites

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable. 
-->

**OS Testing**:

* [ ] iOS 11
* [ ] iOS 12
* [ ] iOS 13
* [ ] iOS 14

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
