### PR TITLE
[README] Update readme file about dependencies and SPM

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ DuckDuckGo is growing fast and we continue to expand our fully distributed team.
 
 ## Building
 
-`TrackerRadarKit` has no dependencies and is intended to be used as an imported Swift package.
+`TrackerRadarKit` has one explicit depency (https://github.com/apple/swift-argument-parser) that is automatically resolved when installing the swift package in XCode. It can be added to an XCode project as a swift package dependency or be used as an imported Swift package.
 
 It can be built manually two ways:
 


### PR DESCRIPTION
**Description**:
There is an explicitly declared dependency in the SPM file
```
dependencies: [
        .package(url: "https://github.com/apple/swift-argument-parser", from: "0.4.3")
    ],
```
The readme mentions no dependencies, so I thought it was worth updating the description.
