### PR TITLE
Changes identifier_name SwiftLint rule to have no maximum

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -8,9 +8,7 @@ line_length:
 
 identifier_name:
   min_length: 1
-  max_length:
-    warning: 40
-    error: 60
+  max_length: 1000
 
 type_name:
   min_length: 3


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL:
Tech Design URL:
CC:

**Description**:
As discussed on MM and as per title. It does this by making the max length arbitrarily large, since it seems there's no way to have no max length that I could find (without disabling the identifier_name rules entirely)

**Steps to test this PR**:
1.
1.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable. 
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15

* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
