### PR TITLE
Ignore rules without a supported action type

### DIFF
--- a/Sources/TrackerRadarKit/TrackerData.swift
+++ b/Sources/TrackerRadarKit/TrackerData.swift
@@ -174,6 +174,18 @@ public struct KnownTracker: Codable, Equatable {
         self.rules = rules
     }
 
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        domain = try? container.decode(String.self, forKey: .domain)
+        defaultAction = try? container.decode(KnownTracker.ActionType.self, forKey: .defaultAction)
+        owner = try? container.decode(KnownTracker.Owner.self, forKey: .owner)
+        prevalence = try? container.decode(Double.self, forKey: .prevalence)
+        subdomains = try? container.decode([String]?.self, forKey: .subdomains)
+        categories = try? container.decode([String].self, forKey: .categories)
+
+        let customRules = try? container.decode([OptionalValue<KnownTracker.Rule>].self, forKey: .rules)
+        rules = customRules?.compactMap { $0.value } as? [KnownTracker.Rule]
+    }
 }
 
 extension KnownTracker {
@@ -204,4 +216,17 @@ public struct Entity: Codable, Hashable {
         self.prevalence = prevalence
     }
     
+}
+
+private struct OptionalValue<Value: Decodable>: Decodable {
+    public let value: Value?
+
+    public init(from decoder: Decoder) throws {
+        do {
+            let container = try decoder.singleValueContainer()
+            self.value = try container.decode(Value.self)
+        } catch {
+            self.value = nil
+        }
+    }
 }

--- a/Tests/TrackerRadarKitTests/ContentBlockerRulesBuilderTests.swift
+++ b/Tests/TrackerRadarKitTests/ContentBlockerRulesBuilderTests.swift
@@ -47,6 +47,23 @@ class ContentBlockerRulesBuilderTests: XCTestCase {
         }
     }
 
+    func testLoadingUnsupportedRules() throws {
+        let data = JSONTestDataLoader.mockTrackerData
+        guard let mockData = try? JSONDecoder().decode(TrackerData.self, from: data) else {
+            XCTFail("Failed to decode tracker data")
+            return
+        }
+
+        guard let tracker = mockData.findTracker(byCname: "tracker-4.com") else {
+            XCTFail("Failed to find tracker")
+            return
+
+        }
+
+        let expectedNumberOfRules = 1
+        XCTAssertEqual(tracker.rules?.count, expectedNumberOfRules)
+    }
+
     func testLoadingRulesIsDeterministic() {
         let firstGeneration = ContentBlockerRulesBuilder(trackerData: trackerData).buildRules(
             withExceptions: [],

--- a/Tests/TrackerRadarKitTests/ContentBlockerRulesBuilderTests.swift
+++ b/Tests/TrackerRadarKitTests/ContentBlockerRulesBuilderTests.swift
@@ -63,6 +63,13 @@ class ContentBlockerRulesBuilderTests: XCTestCase {
         XCTAssertEqual(tracker.rules?.count, expectedNumberOfRules)
     }
 
+    func testTrackerDataParserPerformance () {
+        let data = JSONTestDataLoader.trackerData
+        measure {
+            _ = try? JSONDecoder().decode(TrackerData.self, from: data)
+        }
+    }
+
     func testLoadingRulesIsDeterministic() {
         let firstGeneration = ContentBlockerRulesBuilder(trackerData: trackerData).buildRules(
             withExceptions: [],

--- a/Tests/TrackerRadarKitTests/ContentBlockerRulesBuilderTests.swift
+++ b/Tests/TrackerRadarKitTests/ContentBlockerRulesBuilderTests.swift
@@ -57,7 +57,6 @@ class ContentBlockerRulesBuilderTests: XCTestCase {
         guard let tracker = mockData.findTracker(byCname: "tracker-4.com") else {
             XCTFail("Failed to find tracker")
             return
-
         }
 
         let expectedNumberOfRules = 1

--- a/Tests/TrackerRadarKitTests/Resources/mockTrackerData.json
+++ b/Tests/TrackerRadarKitTests/Resources/mockTrackerData.json
@@ -86,6 +86,30 @@
                     "cookies": 0.01
                 }
             ]
+        },
+        "tracker-4.com": {
+            "domain": "tracker-4.com",
+            "owner": {
+                "name": "Test Site for Tracker Blocking",
+                "displayName": "Bad Third Party Site",
+                "privacyPolicy": "",
+                "url": "http://tracker.test"
+            },
+            "prevalence": 0.1,
+            "fingerprinting": 3,
+            "cookies": 0.1,
+            "categories": [],
+            "default": "block",
+            "rules": [
+                {
+                    "action": "ignore",
+                    "rule": "tracker-4\\.com\\/breakage"
+                },
+                {
+                    "action": "unsupported-action",
+                    "rule": "tracker-4\\.com\\/unsupported-action"
+                }
+            ]
         }
     },
     "entities": {
@@ -109,16 +133,25 @@
             ],
             "prevalence": 1,
             "displayName": "Tracker 3"
+        },
+        "Tracker 4, Inc.": {
+            "domains": [
+                "tracker-4.com"
+            ],
+            "prevalence": 1,
+            "displayName": "Tracker 4"
         }
     },
     "domains": {
         "tracker-1.com": "Tracker 1",
         "tracker-2.com": "Tracker 2",
-        "tracker-3.com": "Tracker 3"
+        "tracker-3.com": "Tracker 3",
+        "tracker-4.com": "Tracker 4"
     },
     "cnames": {
         "tracker-1.com": "cname.tracker-1.com",
         "tracker-2.com": "cname.tracker-2.com",
         "tracker-3.com": "cname.tracker-3.com",
+        "tracker-4.com": "cname.tracker-4.com"
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1200194497630846/1203790344085047/f

**Description**:
This is just a change on the parser itself to ignore rules with action types we don't support. Besides that, there should be no changes in behavior.

**Steps to test this PR**:
1. Run tests
2. Drop BSK on iOS/macOS projects
3. Do a smoke test + run automated tests

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15

* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
