### PR TITLE
Expose tracker ownedBy field

### DIFF
--- a/Sources/TrackerRadarKit/TrackerData.swift
+++ b/Sources/TrackerRadarKit/TrackerData.swift
@@ -81,10 +81,12 @@ public struct KnownTracker: Codable, Equatable {
         
         public let name: String?
         public let displayName: String?
+        public let ownedBy: String?
 
-        public init(name: String?, displayName: String?) {
+        public init(name: String?, displayName: String?, ownedBy: String?) {
             self.name = name
             self.displayName = displayName
+            self.ownedBy = ownedBy
         }
     
     }

--- a/Tests/TrackerRadarKitTests/KnownTrackerTests.swift
+++ b/Tests/TrackerRadarKitTests/KnownTrackerTests.swift
@@ -45,4 +45,30 @@ class KnownTrackerTests: XCTestCase {
         XCTAssertNil(tracker.category)
     }
 
+    func testWhenTrackerIsOwnedByParentThenOwnedByIsNotEmpty() throws {
+        // GIVEN
+        let trackerData = try JSONDecoder().decode(TrackerData.self, from: JSONTestDataLoader.trackerData)
+
+        // WHEN
+        var owner = trackerData.trackers["instagram.com"]?.owner
+        // THEN assert Instagram is owned by Facebook
+        XCTAssertEqual(owner?.ownedBy, "Facebook, Inc.")
+
+        // WHEN
+        owner = trackerData.trackers["youtube.com"]?.owner
+        // Assert Youtube.com is owned by Google
+        XCTAssertEqual(owner?.ownedBy, "Google LLC")
+    }
+
+    func testWhenTrackerIsNotOwnedByParentThenOwnedByIsEmpty() throws {
+        // GIVEN
+        let trackerData = try JSONDecoder().decode(TrackerData.self, from: JSONTestDataLoader.trackerData)
+
+        // WHEN
+        let owner = try XCTUnwrap(trackerData.trackers["insightexpressai.com"]).owner
+
+        // THEN
+        XCTAssertNil(owner?.ownedBy)
+    }
+
 }

--- a/Tests/TrackerRadarKitTests/Resources/trackerData.json
+++ b/Tests/TrackerRadarKitTests/Resources/trackerData.json
@@ -12875,10 +12875,10 @@
         "instagram.com": {
             "domain": "instagram.com",
             "owner": {
-                "name": "Facebook, Inc.",
-                "displayName": "Facebook",
-                "privacyPolicy": "https://help.instagram.com/402411646841720",
-                "url": "http://instagram.com"
+                "name": "Instagram",
+                "displayName": "Instagram (Facebook)",
+                "localizedName": "Instagram",
+                "ownedBy": "Facebook, Inc."
             },
             "prevalence": 0.00754,
             "fingerprinting": 2,
@@ -29324,6 +29324,24 @@
                     "cookies": 0.0000152
                 }
             ]
+        },
+        "youtube.com": {
+            "domain": "youtube.com",
+            "owner": {
+                "name": "Youtube",
+                "displayName": "Youtube (Google)",
+                "localizedName": "Youtube",
+                "ownedBy": "Google LLC"
+            },
+            "prevalence": 0.0694,
+            "fingerprinting": 3,
+            "cookies": 0.0628,
+            "categories": [
+                "Ad Motivated Tracking",
+                "Content Delivery",
+                "Embedded Content"
+            ],
+            "default": "ignore"
         },
         "zadn.vn": {
             "domain": "zadn.vn",


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1176956903599313/1208164650000833/f

**Description**:
There’s an existing [issue](https://app.asana.com/0/0/1207970856546695/1208097565947206/f) that causes showing the wrong education dialog for websites that are owned by a major network like Facebook and Google.

In addition, the Privacy Dashboard [does not reflect weather an entity is owned by a major tracker](https://app.asana.com/0/0/1207970856546695/1208114308033513/f)

This PR exposes the field “ownedBy” with the purpose of identifying when a tracker is owned by another entity.  e.g. Instagram is ownedBy is Facebook

**Steps to test this PR**:
1. Ensure tests pass

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15

* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
