### PR TITLE
Update GH runner

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -26,7 +26,7 @@ jobs:
 
     name: Run unit tests
 
-    runs-on: macos-12
+    runs-on: macos-latest
     timeout-minutes: 30
 
     steps:


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL:
Tech Design URL:
CC:

**Description**:
macOS 12 are not available anymore in GHA. This PR updates the `pr.yml` workflow to use `macos-latest`. 

**Steps to test this PR**:
1. Check CI is green.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable. 
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15

* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
