### PR TITLE
Make library supporting Swift 6 language mode

### DIFF
--- a/Package@swift-6.swift
+++ b/Package@swift-6.swift
@@ -1,0 +1,45 @@
+// swift-tools-version:6.0
+//
+//  TrackerBlockerKit
+//
+//  Copyright © 2021 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import PackageDescription
+
+let package = Package(
+    name: "TrackerRadarKit",
+    products: [
+        .library(
+            name: "TrackerRadarKit",
+            targets: ["TrackerRadarKit"])
+    ],
+    dependencies: [],
+    targets: [
+        .target(
+            name: "TrackerRadarKit",
+            dependencies: []),
+        .testTarget(
+            name: "TrackerRadarKitTests",
+            dependencies: ["TrackerRadarKit"],
+            resources: [
+                .process("Resources/trackerData.json"),
+                .process("Resources/mockTrackerData.json")
+            ]),
+        .testTarget(
+            name: "TrackerRadarKitPerformanceTests",
+            dependencies: ["TrackerRadarKit"])
+    ]
+)

--- a/Sources/TrackerRadarKit/ContentBlockerRule.swift
+++ b/Sources/TrackerRadarKit/ContentBlockerRule.swift
@@ -20,11 +20,11 @@ import Foundation
 import os
 
 // swiftlint:disable nesting
-public struct ContentBlockerRule: Codable, Hashable {
+public struct ContentBlockerRule: Sendable, Codable, Hashable {
 
-    public struct Trigger: Codable, Hashable {
+    public struct Trigger: Sendable, Codable, Hashable {
 
-        public enum ResourceType: String, Codable, CaseIterable {
+        public enum ResourceType: String, Sendable, Codable, CaseIterable {
 
             case document
             case image
@@ -38,14 +38,14 @@ public struct ContentBlockerRule: Codable, Hashable {
 
         }
         
-        public enum LoadType: String, Codable {
+        public enum LoadType: String, Sendable, Codable {
          
             case thirdParty = "third-party"
             case firstParty = "first-party"
             
         }
 
-        public enum LoadContext: String, Codable {
+        public enum LoadContext: String, Sendable, Codable {
             case topFrame = "top-frame"
             case childFrame = "child-frame"
         }
@@ -117,9 +117,9 @@ public struct ContentBlockerRule: Codable, Hashable {
         }
     }
 
-    public struct Action: Codable, Hashable {
+    public struct Action: Codable, Sendable, Hashable {
     
-        public enum ActionType: String, Codable {
+        public enum ActionType: String, Sendable, Codable {
             
             case block
             case ignorePreviousRules = "ignore-previous-rules"

--- a/Sources/TrackerRadarKit/ContentBlockerRulesBuilder.swift
+++ b/Sources/TrackerRadarKit/ContentBlockerRulesBuilder.swift
@@ -18,7 +18,7 @@
 
 import Foundation
 
-public struct ContentBlockerRulesBuilder {
+public struct ContentBlockerRulesBuilder: Sendable {
 
     struct Constants {
         // in the scheme .* overmatches and "OR" does not work

--- a/Sources/TrackerRadarKit/TrackerData.swift
+++ b/Sources/TrackerRadarKit/TrackerData.swift
@@ -18,13 +18,13 @@
 
 import Foundation
 
-public struct TrackerData: Codable, Equatable {
+public struct TrackerData: Sendable, Codable, Equatable {
 
     public typealias EntityName = String
     public typealias TrackerDomain = String
     public typealias CnameDomain = String
 
-    public struct TrackerRules {
+    public struct TrackerRules: Sendable {
         
         let tracker: KnownTracker
         
@@ -71,13 +71,13 @@ public struct TrackerData: Codable, Equatable {
     
 }
 
-public struct KnownTracker: Codable, Equatable {
+public struct KnownTracker: Sendable, Codable, Equatable {
 
     public static func == (lhs: KnownTracker, rhs: KnownTracker) -> Bool {
         return lhs.domain == rhs.domain
     }
 
-    public struct Owner: Codable {
+    public struct Owner: Sendable, Codable {
         
         public let name: String?
         public let displayName: String?
@@ -91,10 +91,10 @@ public struct KnownTracker: Codable, Equatable {
     
     }
     
-    public struct Rule: Codable, Hashable, Equatable {
+    public struct Rule: Sendable, Codable, Hashable, Equatable {
         
         // swiftlint:disable nesting
-        public struct Matching: Codable, Hashable {
+        public struct Matching: Sendable, Codable, Hashable {
 
             public let domains: [String]?
             public let types: [String]?
@@ -126,7 +126,7 @@ public struct KnownTracker: Codable, Equatable {
         }
     }
     
-    public enum ActionType: String, Codable {
+    public enum ActionType: String, Sendable, Codable {
         case block
         case ignore
         // blockCTLFB is treated as "block" for rule creation logic
@@ -208,7 +208,7 @@ extension KnownTracker {
     
 }
 
-public struct Entity: Codable, Hashable {
+public struct Entity: Sendable, Codable, Hashable {
 
     public let displayName: String?
     public let domains: [String]?
@@ -222,7 +222,7 @@ public struct Entity: Codable, Hashable {
     
 }
 
-private struct OptionalValue<Value: Decodable>: Decodable {
+private struct OptionalValue<Value: Decodable & Sendable>: Sendable, Decodable {
     public let value: Value?
 
     public init(from decoder: Decoder) throws {

--- a/Sources/TrackerRadarKit/TrackerException.swift
+++ b/Sources/TrackerRadarKit/TrackerException.swift
@@ -18,9 +18,9 @@
 
 import Foundation
 
-public struct TrackerException {
+public struct TrackerException: Sendable {
 
-    public enum Matching {
+    public enum Matching: Sendable {
         case all
         case domains([String])
         case none

--- a/Tests/TrackerRadarKitPerformanceTests/NextTrackerDataSetPerformanceTests.swift
+++ b/Tests/TrackerRadarKitPerformanceTests/NextTrackerDataSetPerformanceTests.swift
@@ -65,6 +65,7 @@ class NextTrackerDataSetPerformanceTests: XCTestCase {
         print("TDS files prepared")
     }
     
+    @MainActor
     func testPerformanceOfNext_iOSTDS() throws {
         let utAverage = try runPerformanceTest(tds: utTDS, name: "UT TDS")
         
@@ -78,6 +79,7 @@ class NextTrackerDataSetPerformanceTests: XCTestCase {
         }
     }
         
+    @MainActor
     func runPerformanceTest(tds: TrackerData, name: String) throws -> TimeInterval {
         var allAverages: [TimeInterval] = []
         
@@ -100,6 +102,7 @@ class NextTrackerDataSetPerformanceTests: XCTestCase {
         return finalAverage
     }
     
+    @MainActor
     func performSingleRun(store: WKContentRuleListStore, ruleList: String, run: Int, numberOfIterations: Int, name: String) throws -> TimeInterval {
         var totalTime: TimeInterval = 0
         
@@ -121,6 +124,7 @@ class NextTrackerDataSetPerformanceTests: XCTestCase {
         return String(data: data, encoding: .utf8)!
     }
     
+    @MainActor
     func measureSingleRun(store: WKContentRuleListStore, ruleList: String) -> TimeInterval {
         let time = CACurrentMediaTime()
         let expectation = expectation(description: "Compiled")
@@ -136,6 +140,7 @@ class NextTrackerDataSetPerformanceTests: XCTestCase {
         return CACurrentMediaTime() - time
     }
 
+    @MainActor
     func calculateFinalAverage(_ allAverages: [TimeInterval]) -> TimeInterval {
         let sortedAverages = allAverages.sorted()
         let lowerIndex = Int(Double(sortedAverages.count) * 0.3)


### PR DESCRIPTION
Task/Issue URL: -
Tech Design URL: -
CC: -

**Description**:
This PR enables swift 6 language mode and adopts library to support it when used with Xcode 16.

**Steps to test this PR**:
-

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15

* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
