### PR TITLE
Add regex optimizations to speed up compilation time

### DIFF
--- a/Sources/TrackerRadarKit/ContentBlockerRule.swift
+++ b/Sources/TrackerRadarKit/ContentBlockerRule.swift
@@ -51,7 +51,6 @@ public struct ContentBlockerRule: Codable, Hashable {
         }
 
         let urlFilter: String
-        let urlFilterIsCaseSensitive: Bool?
         let unlessDomain: [String]?
         let ifDomain: [String]?
         let resourceType: [ResourceType]?
@@ -60,7 +59,6 @@ public struct ContentBlockerRule: Codable, Hashable {
 
         enum CodingKeys: String, CodingKey {
             case urlFilter = "url-filter"
-            case urlFilterIsCaseSensitive = "url-filter-is-case-sensitive"
             case unlessDomain = "unless-domain"
             case ifDomain = "if-domain"
             case resourceType = "resource-type"
@@ -68,10 +66,9 @@ public struct ContentBlockerRule: Codable, Hashable {
             case loadContext = "load-context"
         }
 
-        private init(urlFilter: String, urlFilterIsCaseSensitive: Bool? = true, unlessDomain: [String]?, ifDomain: [String]?, 
+        private init(urlFilter: String, unlessDomain: [String]?, ifDomain: [String]?,
                      resourceType: [ResourceType]?, loadType: [LoadType]?, loadContext: [LoadContext]?) {
             self.urlFilter = urlFilter
-            self.urlFilterIsCaseSensitive = urlFilterIsCaseSensitive
             self.unlessDomain = unlessDomain
             self.ifDomain = ifDomain
             self.resourceType = resourceType

--- a/Sources/TrackerRadarKit/ContentBlockerRule.swift
+++ b/Sources/TrackerRadarKit/ContentBlockerRule.swift
@@ -51,6 +51,7 @@ public struct ContentBlockerRule: Codable, Hashable {
         }
 
         let urlFilter: String
+        let urlFilterIsCaseSensitive: Bool?
         let unlessDomain: [String]?
         let ifDomain: [String]?
         let resourceType: [ResourceType]?
@@ -59,6 +60,7 @@ public struct ContentBlockerRule: Codable, Hashable {
 
         enum CodingKeys: String, CodingKey {
             case urlFilter = "url-filter"
+            case urlFilterIsCaseSensitive = "url-filter-is-case-sensitive"
             case unlessDomain = "unless-domain"
             case ifDomain = "if-domain"
             case resourceType = "resource-type"
@@ -66,9 +68,10 @@ public struct ContentBlockerRule: Codable, Hashable {
             case loadContext = "load-context"
         }
 
-        private init(urlFilter: String, unlessDomain: [String]?, ifDomain: [String]?, 
+        private init(urlFilter: String, urlFilterIsCaseSensitive: Bool? = true, unlessDomain: [String]?, ifDomain: [String]?, 
                      resourceType: [ResourceType]?, loadType: [LoadType]?, loadContext: [LoadContext]?) {
             self.urlFilter = urlFilter
+            self.urlFilterIsCaseSensitive = urlFilterIsCaseSensitive
             self.unlessDomain = unlessDomain
             self.ifDomain = ifDomain
             self.resourceType = resourceType

--- a/Sources/TrackerRadarKit/ContentBlockerRule.swift
+++ b/Sources/TrackerRadarKit/ContentBlockerRule.swift
@@ -66,8 +66,12 @@ public struct ContentBlockerRule: Codable, Hashable {
             case loadContext = "load-context"
         }
 
-        private init(urlFilter: String, unlessDomain: [String]?, ifDomain: [String]?,
-                     resourceType: [ResourceType]?, loadType: [LoadType]?, loadContext: [LoadContext]?) {
+        private init(urlFilter: String,
+                     unlessDomain: [String]?,
+                     ifDomain: [String]?,
+                     resourceType: [ResourceType]?,
+                     loadType: [LoadType]?,
+                     loadContext: [LoadContext]?) {
             self.urlFilter = urlFilter
             self.unlessDomain = unlessDomain
             self.ifDomain = ifDomain

--- a/Sources/TrackerRadarKit/ContentBlockerRulesBuilder.swift
+++ b/Sources/TrackerRadarKit/ContentBlockerRulesBuilder.swift
@@ -21,6 +21,7 @@ import Foundation
 public struct ContentBlockerRulesBuilder {
 
     struct Constants {
+        // Optimized per WebKit recommendations: https://webkit.org/blog/4062/targeting-domains-with-content-blockers/
         static let subDomainPrefix = "^[^:]+://+([^:/]+\\.)?"
         static let domainMatchSuffix = "[:/]"
     }

--- a/Sources/TrackerRadarKit/ContentBlockerRulesBuilder.swift
+++ b/Sources/TrackerRadarKit/ContentBlockerRulesBuilder.swift
@@ -21,9 +21,8 @@ import Foundation
 public struct ContentBlockerRulesBuilder {
 
     struct Constants {
-        // in the scheme .* overmatches and "OR" does not work
-        static let subDomainPrefix = "^(https?)?(wss?)?://([a-z0-9-]+\\.)*"
-        static let domainMatchSuffix = "(:?[0-9]+)?/.*"
+        static let subDomainPrefix = "^[^:]+://+([^:/]+\\.)?"
+        static let domainMatchSuffix = "[:/]"
     }
     
     public static let resourceMapping: [String: ContentBlockerRule.Trigger.ResourceType] = [

--- a/Tests/TrackerRadarKitTests/ContentBlockerRulesBuilderTests.swift
+++ b/Tests/TrackerRadarKitTests/ContentBlockerRulesBuilderTests.swift
@@ -53,7 +53,6 @@ class ContentBlockerRulesBuilderTests: XCTestCase {
         andTemporaryUnprotectedDomains: [])
 
         // Optimized per WebKit recommendations: https://webkit.org/blog/4062/targeting-domains-with-content-blockers/
-        // swiftlint:disable:next line_length
         var domainFilter = "^[^:]+://+([^:/]+\\.)?xvideos-cdn\\.com\\/v-c19d94e7937\\/v3\\/js\\/skins\\/min\\/default\\.header\\.static\\.js"
         if let idx = rules.firstIndexOfExactFilter(filter: domainFilter) {
             let nextRule = rules[idx + 1]
@@ -96,7 +95,7 @@ class ContentBlockerRulesBuilderTests: XCTestCase {
         XCTAssertEqual(tracker.rules?.count, expectedNumberOfRules)
     }
 
-    func testTrackerDataParserPerformance () {
+    func testTrackerDataParserPerformance() {
         let data = JSONTestDataLoader.trackerData
         measure {
             _ = try? JSONDecoder().decode(TrackerData.self, from: data)

--- a/Tests/TrackerRadarKitTests/ContentBlockerRulesBuilderTests.swift
+++ b/Tests/TrackerRadarKitTests/ContentBlockerRulesBuilderTests.swift
@@ -33,7 +33,8 @@ class ContentBlockerRulesBuilderTests: XCTestCase {
         andTemporaryUnprotectedDomains: [])
 
         // Test tracker is set up to be blocked
-        if let rule = rules.findExactFilter(filter: "^(https?)?(wss?)?://([a-z0-9-]+\\.)*googleadservices\\.com(:?[0-9]+)?/.*") {
+        // Optimized per WebKit recommendations: https://webkit.org/blog/4062/targeting-domains-with-content-blockers/
+        if let rule = rules.findExactFilter(filter: "^[^:]+://+([^:/]+\\.)?googleadservices\\.com[:/]") {
             XCTAssert(rule.action == .block())
         } else {
             XCTFail("Missing google ad services rule")
@@ -51,8 +52,9 @@ class ContentBlockerRulesBuilderTests: XCTestCase {
         let rules = ContentBlockerRulesBuilder(trackerData: trackerData).buildRules(withExceptions: ["duckduckgo.com"],
         andTemporaryUnprotectedDomains: [])
 
+        // Optimized per WebKit recommendations: https://webkit.org/blog/4062/targeting-domains-with-content-blockers/
         // swiftlint:disable:next line_length
-        var domainFilter = "^(https?)?(wss?)?://([a-z0-9-]+\\.)*xvideos-cdn\\.com\\/v-c19d94e7937\\/v3\\/js\\/skins\\/min\\/default\\.header\\.static\\.js"
+        var domainFilter = "^[^:]+://+([^:/]+\\.)?xvideos-cdn\\.com\\/v-c19d94e7937\\/v3\\/js\\/skins\\/min\\/default\\.header\\.static\\.js"
         if let idx = rules.firstIndexOfExactFilter(filter: domainFilter) {
             let nextRule = rules[idx + 1]
             XCTAssertNotNil(nextRule, "Missing ignore-previous popup type rule")
@@ -64,7 +66,8 @@ class ContentBlockerRulesBuilderTests: XCTestCase {
         }
 
         // Test top level default block rule
-        domainFilter = "^(https?)?(wss?)?://([a-z0-9-]+\\.)*google-analytics\\.com(:?[0-9]+)?/.*"
+        // Optimized per WebKit recommendations
+        domainFilter = "^[^:]+://+([^:/]+\\.)?google-analytics\\.com[:/]"
         if let idx = rules.firstIndexOfExactFilter(filter: domainFilter) {
             let nextRule = rules[idx + 1]
             XCTAssertNotNil(nextRule, "Missing ignore-previous popup type rule")


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1212927343395538?focus=true

**Description**:
Implement WebKit optimized patterns based on https://webkit.org/blog/4062/targeting-domains-with-content-blockers/
The optimizations should result in roughly a 40–50% reduction in compilation time.

**Steps to test this PR**:
1. Make sure tests pass


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the core URL-matching regex for all generated blocking rules; while intended to be equivalent, subtle differences in matching could cause under/over-blocking across many domains.
> 
> **Overview**
> Updates the domain-matching regex used in generated `WKContentRuleList` rules to a more efficient WebKit-recommended pattern by changing `ContentBlockerRulesBuilder.Constants.subDomainPrefix`/`domainMatchSuffix`, affecting all rules built via `.trigger(onDomain:)` and `buildBlockingRules`.
> 
> Adjusts unit tests to assert against the new regex strings and includes minor formatting cleanup (initializer wrapping and a test function name whitespace fix).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 76c5309b09b0f87d754414e9fde47462334a2aea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->